### PR TITLE
change links for waypoint-files to mirror

### DIFF
--- a/data/waypoints.json
+++ b/data/waypoints.json
@@ -3,45 +3,45 @@
   "records": [
     {
       "name": "Australia.cup",
-      "uri": "http://download.xcsoar.org/waypoints/Australia.cup",
+      "uri": "http://87.102.254.100/waypoints/Australia.cup",
       "type": "waypoint",
       "area": "au",
-      "update": "2013-02-17"
+      "update": "2015-08-17"
     },
     {
       "name": "France.cup",
-      "uri": "http://download.xcsoar.org/waypoints/France.cup",
+      "uri": "http://87.102.254.100/waypoints/France.cup",
       "type": "waypoint",
       "area": "fr",
-      "update": "2013-02-17"
+      "update": "2015-08-17"
     },
     {
       "name": "Germany.cup",
-      "uri": "http://download.xcsoar.org/waypoints/Germany.cup",
+      "uri": "http://87.102.254.100/waypoints/Germany.cup",
       "type": "waypoint",
       "area": "de",
-      "update": "2013-02-17"
+      "update": "2015-08-17"
     },
     {
       "name": "Netherlands.cup",
-      "uri": "http://download.xcsoar.org/waypoints/Netherlands.cup",
+      "uri": "http://87.102.254.100/waypoints/Netherlands.cup",
       "type": "waypoint",
       "area": "nl",
-      "update": "2013-02-17"
+      "update": "2015-08-17"
     },
     {
       "name": "Poland.cup",
-      "uri": "http://download.xcsoar.org/waypoints/Poland.cup",
+      "uri": "http://87.102.254.100/waypoints/Poland.cup",
       "type": "waypoint",
       "area": "pl",
-      "update": "2013-02-17"
+      "update": "2015-08-17"
     },
     {
       "name": "Italy.cup",
-      "uri": "http://download.xcsoar.org/waypoints/Italy.cup",
+      "uri": "http://87.102.254.100/waypoints/Italy.cup",
       "type": "waypoint",
       "area": "it",
-      "update": "2013-02-17"
+      "update": "2015-08-17"
     }
   ]
 }


### PR DESCRIPTION
At the moment the links for the waypoint-files all point to nowhere.

Under "http://download.xcsoar.org/waypoints/" there are no longer waypoints available like it was in the past, no idea if this was intended or related to the server problems that occured recently.

There are 2 options:
1. Upload the waypoints to the old server so that they are again available under the old url.
2. Merge this commit to change the urls to a mirror (that was also postet in the forum), this also could be a temporal solution until the things with the server are back to normal.