### PR TITLE
test: Work around request parsing failure

### DIFF
--- a/test.js
+++ b/test.js
@@ -13,12 +13,12 @@ function checkRecord(record) {
     it(record.name, function(done) {
         this.timeout(10000);
 
-        request.head(record.uri, function (error, response) {
-            if (error)
+        var r = request.head(record.uri, function (error, response) {
+            if (error && error.code != 'HPE_INVALID_CONSTANT')
                 throw new Error(record.uri + ' failed with ' + error);
 
-            if (response.statusCode != 200)
-                throw new Error(record.uri + ' returned with HTTP status code ' + response.statusCode);
+            if (r.response.statusCode != 200)
+                throw new Error(record.uri + ' returned with HTTP status code ' + r.response.statusCode);
 
             done();
         });


### PR DESCRIPTION
request was not able to parse the HEAD response of soaringweb due to unknown
reasons. The statusCode however was always present on the request object and
since that is all we need we can just use it like before.

Resolves #40 