### PR TITLE
Update Netherlands airspace in airspace.json

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -136,10 +136,10 @@
     },
     {
       "name": "Netherlands_Airspace.txt",
-      "uri": "https://dl.dropboxusercontent.com/u/27739535/databases/EHv16_3.txt",
+      "uri": "https://dl.dropboxusercontent.com/u/27739535/databases/EHv16_3a.txt",
       "type": "airspace",
       "area": "nl",
-      "update": "2016-03-31"
+      "update": "2016-05-09"
     },
     {
       "name": "New_Zealand_Airspace.txt",


### PR DESCRIPTION
Updates in airspace from version 16_3 to 16_3a:
- Changed Schiphol TMA 1 to exclude Lelystad ATZ B
- Minor format changes