### PR TITLE
CI: Use NodeJS v4.x in the default travis dev env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-dist: xenial
+node_js:
+ - "4"
 sudo: false
 env:
   secure: Cxycm98UqGetBaFvU7PwTbrdV7FHPUmUSZO8z4e0te3+J13PJBnNO/fysOlvXhDeM4GN3CeBjcOaKIQGhxJHv/h7b0h7/qwwYrU0leatc9FETagP7EJmFaSYne3SN7D8nJQ3LePmO1TtkFkBZw35anz8Sa75ihupR9wV6ruvFvw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
- - "4"
+ - "8"
 sudo: false
 env:
   secure: Cxycm98UqGetBaFvU7PwTbrdV7FHPUmUSZO8z4e0te3+J13PJBnNO/fysOlvXhDeM4GN3CeBjcOaKIQGhxJHv/h7b0h7/qwwYrU0leatc9FETagP7EJmFaSYne3SN7D8nJQ3LePmO1TtkFkBZw35anz8Sa75ihupR9wV6ruvFvw=


### PR DESCRIPTION
This fixes the build error (`const os = require('os'); [...] SyntaxError: Use of const in strict mode.`) caused by a highly outdated nodejs-version (`v0.10.48`) (see also https://stackoverflow.com/a/23151062/1741342).

Updating to an even newer nodejs-version than `v4.x` should be considered but I've no clue about what is appropriate.
@Turbo87 Can you give an advice which nodejs-version whe should target and how to update the dependencies to meet this version?