### PR TITLE
New Waypoints 2018a for BGA

### DIFF
--- a/data/waypoints-special.json
+++ b/data/waypoints-special.json
@@ -3,10 +3,10 @@
   "records": [
     {
       "name": "BGA2018.dat",
-      "uri": "http://www.nvgc.org.uk/BGA2018.dat",
+      "uri": "http://www.nvgc.org.uk/BGA2018a.dat",
       "type": "waypoint",
       "area": "uk",
-      "update": "2018-04-18"
+      "update": "2018-05-07"
     }
   ]
 }


### PR DESCRIPTION
New Waypoints version. The questions is whether we should rename the destination file to 2018a?