### PR TITLE
Switching to device database for OGN, as flarmnet is not available

### DIFF
--- a/data/flarmnet.json
+++ b/data/flarmnet.json
@@ -1,8 +1,8 @@
 {
-  "title": "FlarmNet",
+  "title": "OGN DDB (flarmnet) ",
   "records": [{
     "name": "data.fln",
-    "uri": "http://www.flarmnet.org/files/data.fln",
+    "uri": "http://ddb.glidernet.org/download/download-fln.php",
     "type": "flarmnet",
     "update": "daily"
   }]


### PR DESCRIPTION
Flarmnet will be gone a few days or weeks as they are reconstructing. In the meantime we should provide the ogn database. 