### PR TITLE
TravisCI: Remove deprecated `sudo: false` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
  - "8"
-sudo: false
 env:
   secure: Cxycm98UqGetBaFvU7PwTbrdV7FHPUmUSZO8z4e0te3+J13PJBnNO/fysOlvXhDeM4GN3CeBjcOaKIQGhxJHv/h7b0h7/qwwYrU0leatc9FETagP7EJmFaSYne3SN7D8nJQ3LePmO1TtkFkBZw35anz8Sa75ihupR9wV6ruvFvw=
   global:


### PR DESCRIPTION
see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration