### PR TITLE
url now hosted at download.xcsoar.org new waypoint-special mechanism

### DIFF
--- a/data/waypoints-special.json
+++ b/data/waypoints-special.json
@@ -3,8 +3,8 @@
   "records": [
     {
       "name": "2019_Hotzenwald_V11.cup",
-      "uri": "http://www.soaringspot.com/en_gb/download-contest-file/2755-14354",
-      "type": "airspace",
+      "uri": "http://download.xcsoar.org/waypoint-special/2019_Hotenzwald_V11.cup",
+      "type": "waypoints",
       "area": "de",
       "update": "2019-05-16"
     }

--- a/data/waypoints-special.json
+++ b/data/waypoints-special.json
@@ -3,7 +3,7 @@
   "records": [
     {
       "name": "2019_Hotzenwald_V11.cup",
-      "uri": "http://download.xcsoar.org/waypoint-special/2019_Hotenzwald_V11.cup",
+      "uri": "http://download.xcsoar.org/waypoints-special/2018_schwarzwald_landefelder.cup",
       "type": "waypoints",
       "area": "de",
       "update": "2019-05-16"


### PR DESCRIPTION
depends on https://github.com/XCSoar/xcsoar-data-content/pull/79