### PR TITLE
split newzealand into north/south new airspace for south island.

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -173,11 +173,18 @@
       "update": "2019-05-13"
     },
     {
-      "name": "New_Zealand_Airspace.txt",
+      "name": "New_Zealand_Airspace_NI.txt",
       "uri": "http://soaring.gahsys.com/Airspace/NZ/NIAirspace9Nov2017.txt",
       "type": "airspace",
       "area": "nz",
       "update": "2017-09-11"
+    },
+    {
+      "name": "New_Zealand_Airspace_SI.txt",
+      "uri": "http://soaring.gahsys.com/Airspace/NZ/SI_Airspace_eff_7_Nov_19_v1_OpenAir.txt",
+      "type": "airspace",
+      "area": "nz",
+      "update": "2019-11-07"
     },
     {
       "name": "Poland_Airspace.txt",

--- a/data/airspace.json
+++ b/data/airspace.json
@@ -181,7 +181,7 @@
     },
     {
       "name": "New_Zealand_Airspace_SI.txt",
-      "uri": "http://soaring.gahsys.com/Airspace/NZ/SI_Airspace_eff_7_Nov_19_v1_OpenAir.txt",
+      "uri": "http://soaring.gahsys.com/Airspace/NZ/SI_Airspace_eff_7_Nov_19_v1.txt",
       "type": "airspace",
       "area": "nz",
       "update": "2019-11-07"


### PR DESCRIPTION
New Filepath for Northen NewZealand
Split North/South Island. Same ISO code might prove a challenge in the future.