### PR TITLE
Rename UK airspace file

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -253,7 +253,7 @@
       "uri": "http://download.xcsoar.org/airspaces/UK_airspace.txt",
       "type": "airspace",
       "area": "uk",
-      "update": "2019-02-28"
+      "update": "2020-01-28"
     },
     {
       "name": "USA_Airspace.txt",

--- a/data/airspace.json
+++ b/data/airspace.json
@@ -250,7 +250,7 @@
     },
     {
       "name": "UK_Airspace.txt",
-      "uri": "http://download.xcsoar.org/airspaces/UK_airspace.txt",
+      "uri": "http://download.xcsoar.org/airspaces/UK_Airspace.txt",
       "type": "airspace",
       "area": "uk",
       "update": "2020-01-28"

--- a/data/airspace.json
+++ b/data/airspace.json
@@ -250,7 +250,7 @@
     },
     {
       "name": "UK_Airspace.txt",
-      "uri": "http://download.xcsoar.org/airspaces/UK_Airspace_2019_02_28.txt",
+      "uri": "http://download.xcsoar.org/airspaces/UK_airspace.txt",
       "type": "airspace",
       "area": "uk",
       "update": "2019-02-28"


### PR DESCRIPTION
Removed the date from the UK airspace file name to avoid having to update the repository with every airspace update. The airspace file includes date information in the header.