### PR TITLE
Airspace austria

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -10,12 +10,11 @@
     },
     {
       "name": "Austria_Airspace.txt",
-      "uri": "https://www.austrocontrol.at/jart/prj3/austro_control/data/dokumente/austria_acg_airspaces_2018-07-19_xcsoar_2018-08-24_1108106.txt",
-      "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_2019-03-28_2019-02-22_1402223.txt",
+      "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_2020-03-26_xcsoar_2020-01-21_1101650.txt",
 
       "type": "airspace",
       "area": "at",
-      "update": "2019-02-21"
+      "update": "2020-03-26"
     },
     {
       "name": "BelgiumLux_Airspace_Week.txt",


### PR DESCRIPTION
Removed the outdated airspace uris for austria and added the current airspace file from austrocontrol eaip.

[Source](https://www.austrocontrol.at/piloten/vor_dem_flug/aim_produkte/luftraumstruktur)