### PR TITLE
French airspace: update link to file

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -81,10 +81,10 @@
     },
     {
       "name": "France_Airspace.txt",
-      "uri": "http://soaring.gahsys.com/Airspace/FR/190523__AIRSPACE_FRANCE_2019-05.txt", 
+      "uri": "http://soaring.gahsys.com/Airspace/FR/France_20-04.txt", 
       "type": "airspace",
       "area": "fr",
-      "update": "2019-05-23"
+      "update": "2020-04-23"
     },
     {
       "name": "Germany_Airspace.txt",


### PR DESCRIPTION
Following issue #151, the French airspace file was updated on the http://soaring.gahsys.com website.

This PR updates the information about the French airspace.

Note sure about the update date: I set it to 2020-04-23 because the header of the file states the information source is "AIP FRANCE 2020/04/23". However, the file was uploaded on the French Gliding Federation on 2020-05-05. 

So, if this PR is fine, this closes #151.