### PR TITLE
Update Sweden airspace

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -227,10 +227,10 @@
     },
     {
       "name": "Sweden_Airspace.txt",
-      "uri": "https://www.flygsport.se/globalassets/svenska-segelflygforbundet/luftrum/sverige-2020-cu-rev1.txt",
+      "uri": "https://www.segelflyget.se/globalassets/svenska-segelflygforbundet/luftrum/sverige-2020-cu-rev2.txt",
       "type": "airspace",
       "area": "se",
-      "update": "2020-04-08"
+      "update": "2020-05-21"
     },
     {
       "name": "Switzerland_Airspace.txt",


### PR DESCRIPTION
This one is a bit weird, because the changes are said to be starting at 2020-05-21, but today it is 2020-05-14. However, the old airspace file (sverige-2020-cu-rev1.txt) is no longer available, so it's better that we submit this new one (sverige-2020-cu-rev2.txt) instead.