### PR TITLE
Update Sweden airspace to 2020-rev7

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -234,10 +234,10 @@
     },
     {
       "name": "Sweden_Airspace.txt",
-      "uri": "http://soaring.gahsys.com/Airspace/SE/Sverige-2020-CU-rev6.txt",
+      "uri": "https://www.segelflyget.se/globalassets/svenska-segelflygforbundet/luftrum/sverige-2020-cu-rev7.txt",
       "type": "airspace",
       "area": "se",
-      "update": "2020-09-10"
+      "update": "2020-11-05"
     },
     {
       "name": "Switzerland_Airspace.txt",


### PR DESCRIPTION
Changed from gahsys.com to segelflyget.se as source because the former had screwed up encoding of the file.