### PR TITLE
Update Hungary airspace to 2020v7

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -123,10 +123,10 @@
     },
     {
       "name": "Hungary_Airspace.txt",
-      "uri": "http://soaring.gahsys.com/Airspace/HU/HungarySUA2017_openair.txt",
+      "uri": "http://soaring.gahsys.com/Airspace/HU/HungarySUA2020_v7.txt",
       "type": "airspace",
       "area": "hu",
-      "update": "2017-09-14"
+      "update": "2021-01-21"
     },
     {
       "name": "Ireland_Airspace.txt",


### PR DESCRIPTION
Please note: The date in the file and the version inside the file implies that this airspace is from 2020, but I couldn't find any information clearly saying from which date this airspace information is valid. For that reason I entered the only date I could find, which is "Dated 21 January 2021" as mentioned inside the file.