### PR TITLE
updated Austrian Airspace valid from 2020-12-03

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -10,11 +10,11 @@
     },
     {
       "name": "Austria_Airspace.txt",
-      "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_2020-06-18_xcsoar_2020-05-05_1105482.txt",
+      "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_2020-12-03_xcsoar_2020-10-22_0710894.txt",
 
       "type": "airspace",
       "area": "at",
-      "update": "2020-06-18"
+      "update": "2020-12-03"
     },
     {
       "name": "BelgiumLux_Airspace_Week.txt",


### PR DESCRIPTION
Updated the austrian airspace link.

Source: e-aip austrocontrol
https://www.austrocontrol.at/piloten/vor_dem_flug/aim_produkte/luftraumstruktur