### PR TITLE
Update Sweden airspace

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -234,10 +234,10 @@
     },
     {
       "name": "Sweden_Airspace.txt",
-      "uri": "https://www.segelflyget.se/globalassets/svenska-segelflygforbundet/luftrum/sverige-2020-cu-rev8.txt",
+      "uri": "https://www.segelflyget.se/globalassets/svenska-segelflygforbundet/luftrum/sverige-luftrum-2021-rev0.txt",
       "type": "airspace",
       "area": "se",
-      "update": "2020-12-03"
+      "update": "2021-03-25"
     },
     {
       "name": "Switzerland_Airspace.txt",


### PR DESCRIPTION
Source is https://www.segelflyget.se/Verksamhet/Luftrum/ and the new data is valid from 2021-03-25.