### PR TITLE
Update to canonical URLs for soaringweb.org

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -3,7 +3,7 @@
   "records": [
     {
       "name": "Australia_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/AU/australia_class_all_20_11_05.txt",
+      "uri": "https://soaringweb.org/Airspace/AU/australia_class_all_20_11_05.txt",
       "type": "airspace",
       "area": "au",
       "update": "2020-11-05"
@@ -18,21 +18,21 @@
     },
     {
       "name": "BelgiumLux_Airspace_Week.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/BE/BELLUX_WEEK_200408c.txt",
+      "uri": "https://soaringweb.org/Airspace/BE/BELLUX_WEEK_200408c.txt",
       "type": "airspace",
       "area": "be",
       "update": "2020-05-02"
     },
     {
       "name": "BelgiumLux_Airspace_Weekend.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/BE/BELLUX_WEEKEND_200408.txt",
+      "uri": "https://soaringweb.org/Airspace/BE/BELLUX_WEEKEND_200408.txt",
       "type": "airspace",
       "area": "be",
       "update": "2020-03-22"
     },
     {
       "name": "Brazil_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/BR/2017_06_05_CBVL_BRASIL_TOTAL_R1.txt",
+      "uri": "https://soaringweb.org/Airspace/BR/2017_06_05_CBVL_BRASIL_TOTAL_R1.txt",
       "type": "airspace",
       "area": "br",
       "update": "2017-10-04"
@@ -67,21 +67,21 @@
     },
     {
       "name": "Croatia_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/HR/HRV-2012.txt",
+      "uri": "https://soaringweb.org/Airspace/HR/HRV-2012.txt",
       "type": "airspace",
       "area": "hr",
       "update": "2013-05-08"
     },
     {
       "name": "Denmark_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/DK/DK-OpenAir-AllinOne-20200615.txt",
+      "uri": "https://soaringweb.org/Airspace/DK/DK-OpenAir-AllinOne-20200615.txt",
       "type": "airspace",
       "area": "dk",
       "update": "2020-06-15"
     },
     {
       "name": "Finland_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/FI/finland_airspace_200228.txt",
+      "uri": "https://soaringweb.org/Airspace/FI/finland_airspace_200228.txt",
       "type": "airspace",
       "area": "fi",
       "update": "2020-02-28"
@@ -116,56 +116,56 @@
     },
     {
       "name": "Greece_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/GR/greece_03.txt",
+      "uri": "https://soaringweb.org/Airspace/GR/greece_03.txt",
       "type": "airspace",
       "area": "gr",
       "update": "2016-04-10"
     },
     {
       "name": "Hungary_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/HU/HungarySUA2020_v7.txt",
+      "uri": "https://soaringweb.org/Airspace/HU/HungarySUA2020_v7.txt",
       "type": "airspace",
       "area": "hu",
       "update": "2021-01-21"
     },
     {
       "name": "Ireland_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/EI/IrelandSua2018a.txt",
+      "uri": "https://soaringweb.org/Airspace/EI/IrelandSua2018a.txt",
       "type": "airspace",
       "area": "ie",
       "update": "2018-03-25"
     },
     {
       "name": "Israel_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/IS/israel_2014_v01.txt",
+      "uri": "https://soaringweb.org/Airspace/IS/israel_2014_v01.txt",
       "type": "airspace",
       "area": "il",
       "update": "2016-01-13"
     },
     {
       "name": "Italy_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/IT/Italia_May2018.txt",
+      "uri": "https://soaringweb.org/Airspace/IT/Italia_May2018.txt",
       "type": "airspace", 
       "area": "it",
       "update": "2018-05-23"
     },
     {
       "name": "Japan_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/JP/JapanAS190330.txt",
+      "uri": "https://soaringweb.org/Airspace/JP/JapanAS190330.txt",
       "type": "airspace", 
       "area": "jp",
       "update": "2019-04-10"
     },
     {
       "name": "Latvia_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/LV/lv_2014_05_04.txt",
+      "uri": "https://soaringweb.org/Airspace/LV/lv_2014_05_04.txt",
       "type": "airspace",
       "area": "lv",
       "update": "2014-05-04"
     },
     {
       "name": "Lithuania_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/LT/LT_2012.txt",
+      "uri": "https://soaringweb.org/Airspace/LT/LT_2012.txt",
       "type": "airspace",
       "area": "lt",
       "update": "2012-05-29"
@@ -193,13 +193,13 @@
     },
     {
       "name": "Poland_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/PL/2018_08_05_Poland_Airspaces.txt",
+      "uri": "https://soaringweb.org/Airspace/PL/2018_08_05_Poland_Airspaces.txt",
       "type": "airspace",
       "area": "po",
       "update": "2018-08-13"
     },
     { "name": "Romania_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/RO/romanian_airspace_2017.txt",
+      "uri": "https://soaringweb.org/Airspace/RO/romanian_airspace_2017.txt",
       "type": "airspace",
       "area": "ro",
       "update": "2017-06-12"
@@ -213,21 +213,21 @@
     },
     {
       "name": "SouthAfrica_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/ZA/SSSA-SA+Airspace-Effective+28FEB2019-Work+in+progress.txt",
+      "uri": "https://soaringweb.org/Airspace/ZA/SSSA-SA+Airspace-Effective+28FEB2019-Work+in+progress.txt",
       "type": "airspace",
       "area": "za",
       "update": "2019-02-28"
     },
     {
       "name": "Slovenia_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/SI/si_2016.04.txt",
+      "uri": "https://soaringweb.org/Airspace/SI/si_2016.04.txt",
       "type": "airspace",
       "area": "si",
       "update": "2016-03-31"
     },
     {
       "name": "Spain_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/ES/SUASpain202004.full.txt",
+      "uri": "https://soaringweb.org/Airspace/ES/SUASpain202004.full.txt",
       "type": "airspace",
       "area": "es",
       "update": "2020-04-01"
@@ -241,14 +241,14 @@
     },
     {
       "name": "Switzerland_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/CH/CH-Luftraum_2020_04_29.txt",
+      "uri": "https://soaringweb.org/Airspace/CH/CH-Luftraum_2020_04_29.txt",
       "type": "airspace",
       "area": "ch",
       "update": "2020-04-29"
     },
     {
       "name": "Ukraine_Airspace.txt",
-      "uri": "http://soaring.guenther-eichhorn.com/Airspace/UA/AirspaceUkraine_2019_01_03.txt", 
+      "uri": "https://soaringweb.org/Airspace/UA/AirspaceUkraine_2019_01_03.txt", 
       "type": "airspace",
       "area": "ua",
       "update": "2019-01-03"
@@ -262,7 +262,7 @@
     },
     {
       "name": "USA_Airspace.txt",
-      "uri": "https://soaring.guenther-eichhorn.com/Airspace/NA/allusa.v21.02-25.2.txt",
+      "uri": "https://soaringweb.org/Airspace/NA/allusa.v21.02-25.2.txt",
       "type": "airspace",
       "area": "us",
       "update": "2021-02-25"


### PR DESCRIPTION
1) Use soaringweb.org instead of soaring.guenther-eichhorn.com, as this is the domain that is used in the links for airspaces on their website.
2) Use https instead of http, as the website redirects to this.

Closes #191.