### PR TITLE
Fix Belgium-Lux weekend airspace URI & update week airspace URI

### DIFF
--- a/data/airspace.json
+++ b/data/airspace.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "BelgiumLux_Airspace_Weekend.txt",
-      "uri": "https://soaringweb.org/Airspace/BE/BELLUX_WEEK_2021-03-21c.txt",
+      "uri": "https://soaringweb.org/Airspace/BE/BELLUX_WEEKEND_2021-03-21b.txt",
       "type": "airspace",
       "area": "be",
       "update": "2021-03-21"

--- a/data/airspace.json
+++ b/data/airspace.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "BelgiumLux_Airspace_Week.txt",
-      "uri": "https://soaringweb.org/Airspace/BE/BELLUX_WEEK_2021-03-21c.txt",
+      "uri": "https://soaringweb.org/Airspace/BE/BELLUX_WEEK_2021-03-21c1.txt",
       "type": "airspace",
       "area": "be",
       "update": "2021-03-21"


### PR DESCRIPTION
Hi,

Both "WEEK" and "WEEKEND" links for Belgium-Luxembourg in `airspace.json` have been pointing to the "WEEK" airspace file, which is incorrect. The "WEEKEND" URI is now switched to use the actual "WEEKEND" file.

In addition I'm updating "WEEK" link to use the latest "WEEK" airspace file available from SoaringWeb. The one that's currently referenced by XCSoar repo has some syntax issue, resulting in a "parse error", while the latest one is read correctly.

Please let me know if I have to do some additional verification for this to be merged.