### PR TITLE
Add South Africa in its entirety, and removed AFR_GARIEP_DAM subsection.

### DIFF
--- a/data/maps.json
+++ b/data/maps.json
@@ -2,13 +2,6 @@
   "title": "Maps",
   "records": [
     {
-      "name": "AFR_GARIEP_DAM_HighRes.xcm",
-      "uri": "http://download.xcsoar.org/maps/AFR_GARIEP_DAM_HighRes.xcm",
-      "type": "map",
-      "area": "za",
-      "update": "2013-02-16"
-    },
-    {
       "name": "AFR_NAMIBIA_CENTRAL_HighRes.xcm",
       "uri": "http://download.xcsoar.org/maps/AFR_NAMIBIA_CENTRAL_HighRes.xcm",
       "type": "map",

--- a/data/maps.json
+++ b/data/maps.json
@@ -511,6 +511,13 @@
       "type": "map",
       "area": "us",
       "update": "2013-02-16"
+    },
+    {
+      "name": "ZA_HighRes.xcm",
+      "uri": "http://download.xcsoar.org/maps/ZA_HighRes.xcm",
+      "type": "map",
+      "area": "za",
+      "update": "2021-09-16"
     }
   ]
 }


### PR DESCRIPTION
NB: Dependent on https://github.com/XCSoar/xcsoar-data-maps/pull/5 being merged, and the ZA map generating successfully.

Motivation:

* The AFR_GARIEP_DAM map is already ~93% of the land area of South Africa (so rather use the new, entire ZA map), yet does not contain the very popular Cape Gliding Club mountain ridges.
* Gariep Dam is better described as being in the country of South Africa (ZA), as opposed to the continent of Africa.
