### PR TITLE
Add underscore, to match all others

### DIFF
--- a/data/waypoints-by-country.json
+++ b/data/waypoints-by-country.json
@@ -450,7 +450,7 @@
       "update": "2015-11-17"
     },
     {
-      "name": "South Africa.cup",
+      "name": "South_Africa.cup",
       "uri": "http://download.xcsoar.org/waypoints/South_Africa.cup",
       "type": "waypoint",
       "area": "za",


### PR DESCRIPTION
Additionally, the convention seems to be: `"name"` matches `"uri"` filename.