### PR TITLE
Airspace: add Australia HG/PG SiteGuide

### DIFF
--- a/data/airspace-special.json
+++ b/data/airspace-special.json
@@ -21,6 +21,13 @@
       "type": "airspace",
       "area": "pl",
       "update": "2021-11-01"
+    },
+    {
+      "name": "Australia HG/PG SiteGuide",
+      "uri": "https://siteguide.org.au/siteGuide.OpenAir.txt",
+      "type": "airspace",
+      "area": "au",
+      "update": "daily"
     }
   ]
 }


### PR DESCRIPTION
This airspace adds Recommended/Restricted/Prohibited LZs and dangers/obstacles (like power lines), for the most active flying sites for hang gliders and paragliders in Australia.
The airspace file is managed by several clubs members and it is continuously updated, due the continuous changes and agreements with the land owners.

Source: https://siteguide.org.au/