### PR TITLE
Test: check for valid filename and extension

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
+var path = require("path");
 var request = require("request");
-
 var repository = require("./");
 
 function describeSection(section) {
@@ -8,9 +8,44 @@ function describeSection(section) {
     });
 }
 
+function isValidFilename (fileName) {
+    var rgxForbiddenChars = /^[^\\/:\*\?"<>\|]+$/; // Forbidden characters \ / : * ? " < > |
+    var rgxNoLeadingDot = /^\./; // Cannot start with dot (.)
+    var rgxForbiddenFileNames = /^(nul|prn|con|aux|lpt[0-9]|com[0-9])(\.|$)/i; // Forbidden file names
+    return rgxForbiddenChars.test(fileName) && !rgxNoLeadingDot.test(fileName) && !rgxForbiddenFileNames.test(fileName);
+}
+
 function checkRecord(record) {
     it(record.name, function(done) {
         this.timeout(10000);
+
+        if (!isValidFilename(record.name)) {
+            throw new Error(record.name + " is an invalid filename");
+        }
+
+        var expectExt = null;
+        switch (record.type) {
+            case "map":
+                expectExt = "xcm";
+                break;
+            case "airspace":
+                expectExt = "txt";
+                break;
+            case "waypoint":
+                expectExt = "cup";
+                break;
+            case "waypoint-details":
+                expectExt = "txt";
+                break;
+            case "flarmnet":
+                expectExt = "fln";
+                break;
+            default:
+                break;
+        }
+        if (expectExt && path.extname(record.name).substr(1) !== expectExt) {
+            throw new Error(record.name + " has an invalid extension for its type (expected \"" + expectExt + "\")");
+        }
 
         var r = request.head(record.uri, function (error, response) {
             if (error && error.code !== "HPE_INVALID_CONSTANT") {


### PR DESCRIPTION
Added 2 extra checks in the _test_ script:
1) Check for a valid Unix/Windows filename ([source](https://stackoverflow.com/a/11101624))
2) Check is the extension matches the type (skips if _type_ is not set)

**NB**: it requires #220 to be merged first in order to pass the test.

Example of output:
<img width="714" alt="Screen Shot 2021-12-11 at 12 48 56 pm" src="https://user-images.githubusercontent.com/5859926/145659783-9a28d1c2-589f-43da-999c-28e4d950e1e9.png">

